### PR TITLE
Hotfix/queryrecipes to recipedbview

### DIFF
--- a/receke/database/db.json
+++ b/receke/database/db.json
@@ -130,11 +130,11 @@
           "quantity": "1 chorro"
         },
         {
-          "ingredient": "Almendras",
+          "ingredient": "Almendra",
           "quantity": "1 puñado"
         },
         {
-          "ingredient": "Avellanas",
+          "ingredient": "Avellana",
           "quantity": "1 puñado"
         }
       ]
@@ -223,7 +223,7 @@
     },
     {
       "id": "7",
-      "title": "pasta con setas y calabacín",
+      "title": "Pasta con setas y calabacín",
       "instructions": [
         "Cocer la pasta en agua ligeramente salada el tiempo que indique el fabricante y escurrirla muy bien.",
         "Despuntar el calabacín, lavarlo y cortarlo en medias lunas. Lavar los tomatitos. Limpiar los champiñones, lavarlos, secarlos y cortarlos en láminas. Mezclar todas las especias.",
@@ -614,7 +614,7 @@
     },
     {
       "id": "29",
-      "name": "pasta",
+      "name": "Pasta",
       "category": "🌾Granos",
       "image": "http://localhost:5173/src/assets/media/pasta.png"
     },
@@ -650,7 +650,7 @@
     },
     {
       "id": "35",
-      "name": "Ternera picada",
+      "name": "Carne picada de ternera",
       "category": "🥩Carnes",
       "image": "http://localhost:5173/src/assets/media/carne.png"
     },
@@ -668,7 +668,7 @@
     },
     {
       "id": "38",
-      "name": "Cerdo picado",
+      "name": "Carne picada de cerdo",
       "category": "🥩Carnes",
       "image": "http://localhost:5173/src/assets/media/carne.png"
     },
@@ -689,6 +689,12 @@
       "name": "Queso",
       "category": "🥛Lácteos",
       "image": "http://localhost:5173/src/assets/media/queso.png"
+    },
+    {
+      "id": "42",
+      "name": "Albahaca",
+      "category": "Otros",
+      "image": "http://localhost:5173/src/assets/media/especias.png"
     }
   ],
   "categories": [

--- a/receke/src/stores/RecipesStore.js
+++ b/receke/src/stores/RecipesStore.js
@@ -50,7 +50,6 @@ export const useRecipesStore = defineStore('recipesStore', {
       )
 
       recipe.ingredients = recipeIngredientsWithImage
-      console.log(recipe.ingredients)
 
       this.recipeSelected = await recipe
     },

--- a/receke/src/stores/RecipesStore.js
+++ b/receke/src/stores/RecipesStore.js
@@ -1,21 +1,20 @@
 //import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 
-const baseUrl = import.meta.env.VITE_APP_BACKEND_URL;
+const baseUrl = import.meta.env.VITE_APP_BACKEND_URL
 //console.log("Hola", baseUrl);
 
-export const useRecipesStore = defineStore('recipesStore', {  //el default
-  state: () => ({   //data de default
-    recipes : [],
+export const useRecipesStore = defineStore('recipesStore', {
+  //el default
+  state: () => ({
+    //data de default
+    recipes: [],
 
-    recipeSelected: {
-
-    }
+    recipeSelected: {}
 
     // recipeName: '',
 
     // selectedIngredients: [],
-           
 
     // steps: ["pasoDummy"],
 
@@ -24,14 +23,11 @@ export const useRecipesStore = defineStore('recipesStore', {  //el default
     // isActive: false,
 
     //ingredients : parseInt(localStorage.getItem('ingredients') || []), //obtiene los ingredientes guardados en LocalStorage en futuro quitamos esto cuando pongamos usuarios
-  
-     
   }),
-  getters: {
+  getters: {},
+  actions: {
+    //methods de default
 
-  },
-  actions: {    //methods de default
-    
     async fetchRecipes() {
       let response = await fetch(`${baseUrl}/recipes`)
       let recipes = await response.json()
@@ -40,12 +36,12 @@ export const useRecipesStore = defineStore('recipesStore', {  //el default
 
     async getRecipeById(id) {
       let response = await fetch(`${baseUrl}/recipes/${id}`)
-      let recipes = await response.json()
-      this.recipeSelected = recipes
+      let recipe = await response.json()
+      this.recipeSelected = recipe
     },
 
-    async postRecipe(newRecipe){
-      const url = `${baseUrl}/recipes`;
+    async postRecipe(newRecipe) {
+      const url = `${baseUrl}/recipes`
       await fetch(url, {
         method: 'POST',
         headers: {
@@ -56,11 +52,11 @@ export const useRecipesStore = defineStore('recipesStore', {  //el default
     },
 
     //obtiene un listado de recetas de la base de datos
-    
+
     // marca como seleccionada una receta
-    async setSelectedRecipe(recipe) {
-      this.selectedRecipe = recipe
-    },
+    // async setSelectedRecipe(recipe) {
+    //   this.selectedRecipe = recipe
+    // },
 
     //   async filterRecipesByIngredients(recipes, selectedIngredients) {
     //     console.log("recipes", recipes) //test 1
@@ -74,60 +70,55 @@ export const useRecipesStore = defineStore('recipesStore', {  //el default
 
     //       console.log("despues de la funcion" ,recipesFiltered) //test 3
 
-  // async filterRecipesByIngredients(recipes, selectedIngredients) {
-  //   const matchingRecipes = []
-  //   for (const recipe of recipes) {
-  //     for (const recipeIngredient of recipe.ingredients) {
-  //       for (const selectedIngredient of selectedIngredients) {
-  //         if (selectedIngredient === recipeIngredient.ingredient){
-  //           matchingRecipes.push(recipe)
-  //         }
-  //       }
-  //     }
-  //   }
-  //   console.log()
+    // async filterRecipesByIngredients(recipes, selectedIngredients) {
+    //   const matchingRecipes = []
+    //   for (const recipe of recipes) {
+    //     for (const recipeIngredient of recipe.ingredients) {
+    //       for (const selectedIngredient of selectedIngredients) {
+    //         if (selectedIngredient === recipeIngredient.ingredient){
+    //           matchingRecipes.push(recipe)
+    //         }
+    //       }
+    //     }
+    //   }
+    //   console.log()
 
-  //   this.recipesFiltered = matchingRecipes
+    //   this.recipesFiltered = matchingRecipes
 
-  // }
+    // }
 
-  async filterRecipesByIngredients(recipes, selectedIngredients) {
-    console.log("inside filterRecipesByIngredients")
-    //console.log("esto es el array recipes", recipes);
-    //console.log("esto es el array selectedIngredients", selectedIngredients);
-  
-    let recipesFiltered = [];
-    
-    recipes.forEach(recipe => {
-      let ingredientsFiltered = [];
+    async filterRecipesByIngredients(recipes, selectedIngredients) {
+      console.log('inside filterRecipesByIngredients')
+      //console.log("esto es el array recipes", recipes);
+      //console.log("esto es el array selectedIngredients", selectedIngredients);
 
-      
-      recipe.ingredients.forEach(
-        objIng => {
+      let recipesFiltered = []
+
+      recipes.forEach((recipe) => {
+        let ingredientsFiltered = []
+
+        recipe.ingredients.forEach((objIng) => {
           ingredientsFiltered.push(objIng.ingredient)
+        })
+
+        let matchCount = ingredientsFiltered.filter((ing) =>
+          selectedIngredients.includes(ing)
+        ).length
+        //console.log("match", matchCount);
+        if (matchCount === ingredientsFiltered.length) {
+          recipesFiltered.push({ ...recipe, count: matchCount, matchAll: true })
+        } else if (matchCount >= 1) {
+          recipesFiltered.push({ ...recipe, count: matchCount, matchAll: false })
         }
-      )
+      })
 
+      recipesFiltered.sort((a, b) => b.count - a.count)
 
-    
-      
-    let matchCount = ingredientsFiltered.filter(ing => selectedIngredients.includes(ing)).length;
-      //console.log("match", matchCount);
-      if(matchCount === ingredientsFiltered.length){
-        recipesFiltered.push({...recipe, count: matchCount, matchAll : true});
-      }
-      else if (matchCount >= 1) { 
-        recipesFiltered.push({...recipe, count: matchCount, matchAll : false});
-      }
-    });
+      console.log('después de la función', recipesFiltered) //test 3
 
-    recipesFiltered.sort((a, b) => b.count - a.count);
-    
-  
-    console.log("después de la función", recipesFiltered); //test 3
-  
-    this.recipesFiltered = recipesFiltered;
-  
-    //console.log("después de asignar", this.recipesFiltered); //test 3
-  },
-}})
+      this.recipesFiltered = recipesFiltered
+
+      //console.log("después de asignar", this.recipesFiltered); //test 3
+    }
+  }
+})

--- a/receke/src/views/QueryRecipes.vue
+++ b/receke/src/views/QueryRecipes.vue
@@ -7,7 +7,7 @@ import NavComponent from '@/components/NavComponent.vue'
 export default {
     computed: {
         ...mapState(useIngredientsStore, ['ingredients', 'categories', 'selectedIngredients']),
-        ...mapState(useRecipesStore, ['recipes', 'selectedRecipe', 'recipesFiltered'])
+        ...mapState(useRecipesStore, ['recipes', 'recipesFiltered'])
     },
 
 
@@ -64,12 +64,9 @@ export default {
         //     return `http://localhost:3001/recipes/${recipe.id}`;
         // },
 
-        selectRecipe(recipe) {
-            this.$store.recipes.setSelectedRecipe(recipe);
-
-
-
-        }
+        // selectRecipe(recipe) {
+        //     this.$store.recipes.setSelectedRecipe(recipe);
+        // }
 
     },
 
@@ -101,7 +98,7 @@ export default {
 
             <router-link :to="`/recipe-view/${recipe.id}`">
 
-               <div :class="{ 'bg-green': recipe.matchAll === true }"  @click="selectRecipe(recipe)">
+               <div :class="{ 'bg-green': recipe.matchAll === true }">
                     <div class="image-container"  > 
                     <img :src="recipe.image" :alt="`${recipe.title}`" >
                     </div>

--- a/receke/src/views/RecipeDBView.vue
+++ b/receke/src/views/RecipeDBView.vue
@@ -7,10 +7,6 @@ import NavComponent from '@/components/NavComponent.vue';
 export default {
     methods: {
         ...mapActions(useRecipesStore, ['getRecipeById']),
-        getIngredientImage(ingredient) {
-            const ingredientMatch = this.ingredients.find((item) => item.name === ingredient)
-            return ingredientMatch.image
-        }
     },
     computed: {
         ...mapState(useRecipesStore, ['recipeSelected']),
@@ -28,7 +24,6 @@ export default {
 <template>
 
     <NavComponent link="/query-recipes" :title="recipeSelected.title" />
-
     <div class="recipe-layout-alignment">
         <!-- Recipe image -->
         <div class="recipe-image">
@@ -40,7 +35,7 @@ export default {
             <!-- Ingredients list -->
             <div class="ingredients-list" v-for="(item, index) in recipeSelected.ingredients" :key="index">
                 <div>
-                    <img :src="getIngredientImage(item.ingredient)">
+                    <img :src="item.image">
                     <h4> {{ item.ingredient }} {{ item.quantity }}</h4>
                 </div>
             </div>

--- a/receke/src/views/RecipeDBView.vue
+++ b/receke/src/views/RecipeDBView.vue
@@ -28,6 +28,7 @@ export default {
 <template>
 
     <NavComponent link="/query-recipes" :title="recipeSelected.title" />
+
     <div class="recipe-layout-alignment">
         <!-- Recipe image -->
         <div class="recipe-image">


### PR DESCRIPTION
Solved the errors that appeared on recipeDBView

1. QueryRecipes had a function selectRecipe(recipe) that was triggered when clicking on any recipeCard, but it was not working properly and it was not needed as the recipeSelected{} is assigned when the RecipeDBView is loaded.
2. Some recipes of the database included ingredients that didn't match any ingredient form the ingredients database, causing an error. Fixed database.
3. To prevent asynchronous problemes, the function getIngredientImage(ingredient) is moved to the RecipesStore. Added error handling so that if an ingredient is not found, it returns an error to the console instead of crashing all the page.